### PR TITLE
Make Gemini model configurable and update default to gemini-2.0-flash

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -6,6 +6,7 @@ import { getCurrentUser } from "@/libs/firebase/firebase-admin";
 export const maxDuration = 60; // 60 seconds is the maximum allowed by Vercel.
 
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || "");
+const GEMINI_MODEL = process.env.GEMINI_MODEL || "gemini-2.0-flash";
 
 const tavily = process.env.TAVILY_API_KEY
   ? new TavilyClient({
@@ -53,7 +54,7 @@ export async function POST(req: Request) {
       }
     }
 
-    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-002" });
+    const model = genAI.getGenerativeModel({ model: GEMINI_MODEL });
 
     const prompt = updatedMessages.map(msg => `${msg.role}: ${msg.content}`).join('\n');
     const result = await model.generateContent(prompt);

--- a/app/api/digest/route.ts
+++ b/app/api/digest/route.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { getCurrentUser } from "@/libs/firebase/firebase-admin";
 
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || "");
+const GEMINI_MODEL = process.env.GEMINI_MODEL || "gemini-2.0-flash";
 
 const Knowledge = z.object({
   title: z.string(),
@@ -26,7 +27,7 @@ export async function POST(req: Request) {
 
   try {
     const model = genAI.getGenerativeModel({
-      model: "gemini-1.5-flash-002",
+      model: GEMINI_MODEL,
       generationConfig: { responseMimeType: "application/json" },
     });
 


### PR DESCRIPTION
### Motivation
- The app was failing at runtime with 404s for a removed or unsupported Gemini model identifier (`gemini-1.5-flash-002`).
- Allowing the model ID to be overridden via an environment variable avoids hardcoding deprecated model names and makes deployments configurable.

### Description
- Introduced a `GEMINI_MODEL` constant read from `process.env.GEMINI_MODEL` with a default of `gemini-2.0-flash`.
- Replaced hardcoded `"gemini-1.5-flash-002"` usages with `GEMINI_MODEL` in `app/api/chat/route.ts` and `app/api/digest/route.ts`.
- Kept the existing `generationConfig` behavior and only switched the model selection to the environment-backed value.

### Testing
- Ran `npm run lint` (Next.js/ESLint) and it completed successfully with no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d072ce008332b9fa0bddce6b3d0d)