### PR TITLE
Fix /api/digest 500 when Gemini returns array or wrapped JSON

### DIFF
--- a/app/api/digest/route.ts
+++ b/app/api/digest/route.ts
@@ -11,6 +11,12 @@ const Knowledge = z.object({
   description: z.string(),
 });
 
+const KnowledgeResponse = z.union([
+  Knowledge,
+  z.array(Knowledge).nonempty(),
+  z.object({ result: Knowledge }),
+]);
+
 interface Message {
   role: string;
   content: string;
@@ -48,12 +54,14 @@ Response (in JSON format):
     const result = await model.generateContent(prompt);
     const response = await result.response;
     const text = response.text();
+    const parsedResponse = KnowledgeResponse.parse(JSON.parse(text));
 
-    // Parse the JSON response
-    const parsedResponse = JSON.parse(text);
-
-    // Validate the response against the Knowledge schema
-    const knowledge = Knowledge.parse(parsedResponse);
+    const knowledge =
+      Array.isArray(parsedResponse)
+        ? parsedResponse[0]
+        : "result" in parsedResponse
+          ? parsedResponse.result
+          : parsedResponse;
 
     return NextResponse.json({ result: knowledge });
   } catch (error) {


### PR DESCRIPTION
### Motivation
- Production requests to `POST /api/digest` were failing with `ZodError: Expected object, received array` because Gemini sometimes returns an array or a wrapped object despite the prompt asking for a single JSON object. 

### Description
- Add a `KnowledgeResponse` zod union that accepts a single `Knowledge`, a non-empty array of `Knowledge`, or an object of the form `{ result: Knowledge }`.
- Parse the model `response.text()` with `JSON.parse` and validate it via `KnowledgeResponse.parse` to accept multiple shapes.
- Normalize the validated payload into a single `knowledge` object by selecting the first array element or the `result` field when present.
- Return the normalized `knowledge` in the API response to avoid schema validation errors.

### Testing
- Ran `npm run lint` which passed with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d24db5048332bbb759d3e9ea67dd)