### PR TITLE
Add GA4 tracking for chat_send and knowledge_generate events

### DIFF
--- a/app/chat/ChatClient.tsx
+++ b/app/chat/ChatClient.tsx
@@ -7,6 +7,22 @@ import MessageList from "@/components/chat/MessageList";
 import KnowledgeButton from "@/components/chat/KnowledgeButton";
 import KnowledgeModal from "@/components/chat/KnowledgeModal";
 
+const trackAnalyticsEvent = (
+  eventName: "chat_send" | "knowledge_generate",
+  params: Record<string, string | number | boolean>
+) => {
+  if (typeof window === "undefined") return;
+
+  const windowWithDataLayer = window as Window & {
+    dataLayer?: Record<string, string | number | boolean>[];
+  };
+  windowWithDataLayer.dataLayer = windowWithDataLayer.dataLayer || [];
+  windowWithDataLayer.dataLayer.push({
+    event: eventName,
+    ...params,
+  });
+};
+
 export default function ChatClient() {
   const [messages, setMessages] = useState<{ role: string; content: string }[]>([]);
   const [input, setInput] = useState("");
@@ -26,6 +42,10 @@ export default function ChatClient() {
     setInput("");
 
     setMessages([...newMessages, { role: "assistant", content: "Loading..." }]);
+    trackAnalyticsEvent("chat_send", {
+      web_search_enabled: webSearchEnabled,
+      message_length: input.length,
+    });
 
     try {
       const response = await fetch("/api/chat", {
@@ -79,6 +99,9 @@ export default function ChatClient() {
 
       const { result } = await response.json();
       setKnowledge(result);
+      trackAnalyticsEvent("knowledge_generate", {
+        message_count: messages.length,
+      });
     } catch (error) {
       console.error("Error turning into knowledge:", error);
       setKnowledge({


### PR DESCRIPTION
### Motivation
- Record user interactions (chat sends) and knowledge-generation actions as GA4 events so product/usage analytics can track these key behaviors.

### Description
- Add a reusable `trackAnalyticsEvent` helper in `app/chat/ChatClient.tsx` that safely pushes events to `dataLayer` for GTM/GA4 consumption.
- Emit a `chat_send` event from `handleSubmit` with `web_search_enabled` and `message_length` parameters when a user sends a message.
- Emit a `knowledge_generate` event from `handleTurnIntoKnowledge` on successful digest generation with a `message_count` parameter.
- Implementation assumes GTM is loaded via `NEXT_PUBLIC_GTM_ID` in `app/layout.tsx` so `dataLayer` will be processed by GTM/GA4.

### Testing
- Ran `npm run lint` and the linter completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d4ee79888332a1c69e15cd157ec5)